### PR TITLE
Add transparency report

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -16,3 +16,5 @@
   link: /#faq
 - name: Code of Conduct
   link: /conduct/
+- name: Transparency Report
+  link: /transparency-report/

--- a/_pages/transparency-report.md
+++ b/_pages/transparency-report.md
@@ -3,7 +3,7 @@ title: Prompt Conf 2019 Code of Conduct Transparency Report
 permalink: /transparency-report/
 ---
 
-# Code of Conduct Transparency Report
+# 2019 Code of Conduct Transparency Report
 
 The PromptConf Code of Conduct sets standards for how all PromptConf attendees (e.g. organizers, speakers, volunteers, attendees) interact with others during the conference. Critical to enforcing the Code of Conduct, the PromptConf Code of Conduct strategy developed prioritized several key factors including:
 

--- a/_pages/transparency-report.md
+++ b/_pages/transparency-report.md
@@ -1,0 +1,42 @@
+---
+title: Prompt Conf 2019 Code of Conduct Transparency Report
+permalink: /transparency-report/
+---
+
+# Code of Conduct Transparency Report
+
+The PromptConf Code of Conduct sets standards for how all PromptConf attendees (e.g. organizers, speakers, volunteers, attendees) interact with others during the conference. Critical to enforcing the Code of Conduct, the PromptConf Code of Conduct strategy developed prioritized several key factors including:
+
+- Publicly publishing the Code of Conduct on the website, through conference communications, and in the venue
+- Prioritizing and ensuring accessibility for all PromptConf attendees to issue a report 
+- Writing this transparency report
+
+
+## Accessibility
+
+As a means to ensure that the Code of Conduct was accessible to all PromptConf participants, PromptConf 2019 offered several means for reporting. Below were the ways provided:
+
+- Code of Conduct hotline where three organizers were available by text and phone call
+- Strategic placement of all six organizers for in person access
+- Online review of content associated with PromptConf (e.g. social media)
+- A dedicated room for Code of Conduct reporting 
+
+## Reports
+
+This year, PromptConf organizers were notified of one minor incident, which was not deemed a Code of Conduct violation:
+A photo of a speaker was posted by a conference attendee on social media who did not want to be photographed. The photo was deleted immediately from social media and the speaker was notified.
+
+## Resolution
+
+While PromptConf 2019 had no Code of Conduct violations feedback was offered to help the PromptConf 2020 team improve the overall Code of Conduct work. 
+
+Below are some of the steps the PromptConf team will be investigating:
+
+- Improvement of the photo policy for PromptConf participants, particularly in communication for the photo policy in the venue for the day of the conference
+- Addition of a general speaker slide submission policy prior to the event to better ensure all slides are Code of Conduct compliant
+- Better designation of bathrooms to increase accessibility
+
+## Summary of Reported Incident
+A photo was added on social media of a speaker by another conference attendee. The speaker had expressed they did not want photos taken at the event, but instead wanted a preapproved photo used. The photo was promptly deleted from social media and the speaker was informed.
+
+


### PR DESCRIPTION
# Overview

Includes the Code of Conduct transparency report for the Prompt Conf 2019. 

## Scope of Work

- Adds `_pages/transparency-report.md`
- Modifies `_data/nav.yml` to include `transparency-report`

## Questions

1. Is that all I have to add? Let me know if I missed something!
2. Is it better to add this to a blog? Y'all tell me!